### PR TITLE
Upgrade stencil to 3.1.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ ENV NPM_CONFIG_PREFIX=/home/node/.npm-global
 ENV PATH=$PATH:/home/node/.npm-global/bin
 
 RUN npm install -g ajv-cli@3.3.0
-RUN npm install -g @bigcommerce/stencil-cli@3.1.0 && stencil --version
+RUN npm install -g @bigcommerce/stencil-cli@3.1.1 && stencil --version
 
 USER root
 


### PR DESCRIPTION
Upgrade Stencil CLI: https://github.com/bigcommerce/stencil-cli/releases/tag/3.1.1