### PR TITLE
Identify filesystem before remapping uid and gid

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,24 +3,33 @@
 
 APP_ROOT="/app"
 
-DOCKER_UID=`stat -c "%u" $APP_ROOT`
-DOCKER_GID=`stat -c "%g" $APP_ROOT`
+# When requesting ownership metadata, osxf will return the uid and gid of the requesting process's user.
+# There is no need to remap the containers process ID for macOS hosts
 
-INCUMBENT_USER=`getent passwd $DOCKER_UID | cut -d: -f1`
-INCUMBENT_GROUP=`getent group $DOCKER_GID | cut -d: -f1`
+# Docker does not expose the filesystem information of the host. 
+# Checking for fuse mounts is used determine we are running on a macOS host.
+# This will also be true for Windows which has not been tested.
+MOUNT_FS=`df -Th | grep $APP_ROOT | awk '{print $2}'`
+if [ "$MOUNT_FS" != 'fuse.grpcfuse' ]; then
+  DOCKER_UID=`stat -c "%u" $APP_ROOT`
+  DOCKER_GID=`stat -c "%g" $APP_ROOT`
 
-#echo "Docker: uid = $DOCKER_UID, gid = $DOCKER_GID"
-#echo "Incumbent: user = $INCUMBENT_USER, group = $INCUMBENT_GROUP"
+  INCUMBENT_USER=`getent passwd $DOCKER_UID | cut -d: -f1`
+  INCUMBENT_GROUP=`getent group $DOCKER_GID | cut -d: -f1`
 
-# Once we've established the ids and incumbent ids then we need to free them
-# up (if necessary) and then make the change to node.
+  #echo "Docker: uid = $DOCKER_UID, gid = $DOCKER_GID"
+  #echo "Incumbent: user = $INCUMBENT_USER, group = $INCUMBENT_GROUP"
 
-sed -i 's/^#\ CREATE_MAIL_SPOOL=yes/CREATE_MAIL_SPOOL=no/' /etc/default/useradd
-userdel node
-groupadd --gid ${DOCKER_GID} node
-useradd --gid node --no-log-init --home-dir /home/node --shell /bin/bash --uid ${DOCKER_UID} node
+  # Once we've established the ids and incumbent ids then we need to free them
+  # up (if necessary) and then make the change to node.
 
-chown -R node:node /home/node/.config
+  sed -i 's/^#\ CREATE_MAIL_SPOOL=yes/CREATE_MAIL_SPOOL=no/' /etc/default/useradd
+  userdel node
+  groupadd --gid ${DOCKER_GID} node
+  useradd --gid node --no-log-init --home-dir /home/node --shell /bin/bash --uid ${DOCKER_UID} node
+
+  chown -R node:node /home/node/.config
+fi
 
 cd $APP_ROOT
 


### PR DESCRIPTION
This pull request Resolves #9 by not remaping the containerised `uid` and `gid` when running on macOS.

Unfortunately, there is no great way to determine what the file system of the host is from within the container so I settled on checking for `fuse` which should be tree for docker-for-mac. This will also be true for windows which I have not tested. (This fix may be required for windows also as the file system permission translation for Windows is even more naive).

Another option would be to inject an identifier like `uname` into the entry point but this felt like a list  contained solution.