### PR TITLE
Add curl for use in pipelines

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ EXPOSE 3002/tcp
 
 ARG DEBIAN_INTERACTIVE=noninteractive
 RUN apt-get update && \
-    apt-get --no-install-recommends --assume-yes --quiet install sudo git ca-certificates bzip2 && \ 
+    apt-get --no-install-recommends --assume-yes --quiet install sudo git ca-certificates bzip2 curl && \ 
     rm -rf /var/lib/apt/lists/* && \
     update-ca-certificates
 


### PR DESCRIPTION
My pipeline currently uses a curl request to invalidate a cache after a stencil deployment, however curl is not available. This PR installs curl for use in my pipeline.