### PR TITLE
Add ssh client so npm can use it to install packages via git

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ EXPOSE 3002/tcp
 
 ARG DEBIAN_INTERACTIVE=noninteractive
 RUN apt-get update && \
-    apt-get --no-install-recommends --assume-yes --quiet install sudo git ca-certificates bzip2 curl && \ 
+    apt-get --no-install-recommends --assume-yes --quiet install sudo git ca-certificates bzip2 curl openssh-client && \ 
     rm -rf /var/lib/apt/lists/* && \
     update-ca-certificates
 


### PR DESCRIPTION
Github has removed support for unauthenticated git:// calls. This requires an update to ssh:// for a few packages referencing github repos directly. See: https://github.blog/2021-09-01-improving-git-protocol-security-github/

This PR just adds an ssh client so this can be used in bitbucket pipelines to install packages via ssh.