### PR TITLE
Fix pipeline Support on Node 14

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ EXPOSE 3002/tcp
 
 ARG DEBIAN_INTERACTIVE=noninteractive
 RUN apt-get update && \
-    apt-get --no-install-recommends --assume-yes --quiet install sudo git ca-certificates bzip2 curl openssh-client && \ 
+    apt-get --no-install-recommends --assume-yes --quiet install sudo git ca-certificates bzip2 curl openssh-client python build-essential libsass-dev && \ 
     rm -rf /var/lib/apt/lists/* && \
     update-ca-certificates
 


### PR DESCRIPTION
Added python and build essentials as they are required during an npm install in our build pipeline
Added libsass-dev for sass bindings required by node-sass

These packages were previously pulled in as transitive dependencies in the node 12 slim base container and are no longer available in the node 14 slim base container. They are required during an npm install/ci and build of themes so this PR just adds them in as hard dependencies.