### PR TITLE
Revert ajv-cli to version 3.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ WORKDIR /app
 ENV NPM_CONFIG_PREFIX=/home/node/.npm-global
 ENV PATH=$PATH:/home/node/.npm-global/bin
 
-RUN npm install -g ajv-cli@5.0.0
+RUN npm install -g ajv-cli@3.3.0
 RUN npm install -g @bigcommerce/stencil-cli@7.2.3
 
 USER root


### PR DESCRIPTION
This PR reverts the ajv-cli to version 3.3 as bigcommerce stencil config schema is not compatible with ajv > 7 (ajv-cli 5.0.0 uses ajv 8). The latest version of stencil uses 6.12.5 see: https://github.com/bigcommerce/stencil-cli/blob/master/package.json#L59